### PR TITLE
[ReflectionTS] Removed unexspected conversion to bool in some helper variable templates

### DIFF
--- a/libcxx/include/experimental/reflect
+++ b/libcxx/include/experimental/reflect
@@ -497,7 +497,7 @@ struct _LIBCPP_TEMPLATE_VIS get_source_line
     __metaobject_get_source_line(__unwrap_metaobject_id_v<_Tp>)> {};
 
 template <Object _Tp>
-inline constexpr bool get_source_line_v = get_source_line<_Tp>::value;
+inline constexpr auto get_source_line_v = get_source_line<_Tp>::value;
 
 template <Object _Tp>
 struct _LIBCPP_TEMPLATE_VIS get_source_column
@@ -506,7 +506,7 @@ struct _LIBCPP_TEMPLATE_VIS get_source_column
     __metaobject_get_source_column(__unwrap_metaobject_id_v<_Tp>)> {};
 
 template <Object _Tp>
-inline constexpr bool get_source_column_v = get_source_column<_Tp>::value;
+inline constexpr auto get_source_column_v = get_source_column<_Tp>::value;
 
 template <Variable _Tp>
 struct _LIBCPP_TEMPLATE_VIS get_pointer
@@ -515,7 +515,7 @@ struct _LIBCPP_TEMPLATE_VIS get_pointer
     __metaobject_get_pointer(__unwrap_metaobject_id_v<_Tp>)> {};
 
 template <Variable _Tp>
-inline constexpr bool get_pointer_v = get_pointer<_Tp>::value;
+inline constexpr auto get_pointer_v = get_pointer<_Tp>::value;
 
 template <Constant _Tp>
 struct _LIBCPP_TEMPLATE_VIS get_constant


### PR DESCRIPTION
get_source_line_v, get_source_column_v and get_pointer_v should not convert their result to bool.